### PR TITLE
Issue #16: Updated external function parameters to fix unit tests

### DIFF
--- a/classes/external/chat_3.php
+++ b/classes/external/chat_3.php
@@ -42,8 +42,8 @@ class chat_3 extends external_api {
         return new external_function_parameters([
             "message" => new external_value(PARAM_RAW, "The message value"),
             "courseid" => new external_value(PARAM_TEXT, "The Course ID"),
-            "audio" => new external_value(PARAM_RAW, "The message value", VALUE_OPTIONAL),
-            "lang" => new external_value(PARAM_RAW, "The language value", VALUE_OPTIONAL),
+            "audio" => new external_value(PARAM_RAW, "The message value", VALUE_DEFAULT, null, NULL_ALLOWED),
+            "lang" => new external_value(PARAM_RAW, "The language value", VALUE_DEFAULT, null, NULL_ALLOWED),
         ]);
     }
 

--- a/classes/external/chat_4.php
+++ b/classes/external/chat_4.php
@@ -42,8 +42,8 @@ class chat_4 extends external_api {
         return new external_function_parameters([
             "message" => new external_value(PARAM_RAW, "The message value"),
             "courseid" => new external_value(PARAM_TEXT, "The Course ID"),
-            "audio" => new external_value(PARAM_RAW, "The message value", VALUE_OPTIONAL),
-            "lang" => new external_value(PARAM_RAW, "The language value", VALUE_OPTIONAL),
+            "audio" => new external_value(PARAM_RAW, "The message value", VALUE_DEFAULT, null, NULL_ALLOWED),
+            "lang" => new external_value(PARAM_RAW, "The language value", VALUE_DEFAULT, null, NULL_ALLOWED),
         ]);
     }
 


### PR DESCRIPTION
Close Issue #16.

This change fixes the failing unit tests regarding external function parameters. 

To validate the fix:
1. Deploy a moodle instance with `local_geniai` installed
2. Initialize PHP Unit testing environment
3. Run `vendor/bin/phpunit lib/external/tests/external_api_test.php`
4. See the errors
5. Checkout to `catalyst-master` branch
6. Re-run tests, and see the errors are resolved

Output after fixes:
```
Moodle 4.5.2+ (Build: 20250311), 0a4730866743e33c468d90c7ec0e0175ac1068bd
Php: 8.1.28, mysqli: 8.0.37, OS: Linux 6.8.0-52-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

...............................................................  63 / 949 (  6%)
............................................................... 126 / 949 ( 13%)
............................................................... 189 / 949 ( 19%)
............................................................... 252 / 949 ( 26%)
............................................................... 315 / 949 ( 33%)
............................................................... 378 / 949 ( 39%)
............................................................... 441 / 949 ( 46%)
............................................................... 504 / 949 ( 53%)
............................................................... 567 / 949 ( 59%)
............................................................... 630 / 949 ( 66%)
............................................................... 693 / 949 ( 73%)
............................................................... 756 / 949 ( 79%)
............................................................... 819 / 949 ( 86%)
............................................................... 882 / 949 ( 92%)
............................................................... 945 / 949 ( 99%)
....                                                            949 / 949 (100%)

Time: 41:05.522, Memory: 88.50 MB

OK (949 tests, 5658 assertions)
```