### PR TITLE
Issue #18: Added check for `$_SERVER["REQUEST_URI"]` to prevent failed test

### DIFF
--- a/classes/core_hook_output.php
+++ b/classes/core_hook_output.php
@@ -107,12 +107,15 @@ class core_hook_output {
     private static function local_geniai_addh5p() {
         global $PAGE, $COURSE;
 
-        if (strpos($_SERVER["REQUEST_URI"], "contentbank/") ||
-            strpos($_SERVER["REQUEST_URI"], "course/modedit.php")) {
+        if (isset($_SERVER["REQUEST_URI"])) {
+            if (strpos($_SERVER["REQUEST_URI"], "contentbank/") ||
+                strpos($_SERVER["REQUEST_URI"], "course/modedit.php")) {
 
-            $contextid = \context_course::instance($COURSE->id)->id;
-            $PAGE->requires->strings_for_js(["h5p-manager", "h5p-manager-scorm"], "local_geniai");
-            $PAGE->requires->js_call_amd("local_geniai/h5p", "init", [$contextid]);
+                $contextid = \context_course::instance($COURSE->id)->id;
+                $PAGE->requires->strings_for_js(["h5p-manager", "h5p-manager-scorm"], "local_geniai");
+                $PAGE->requires->js_call_amd("local_geniai/h5p", "init", [$contextid]);
+            }
         }
+        
     }
 }


### PR DESCRIPTION
Closes Issue #18.

Added a check for `$_SERVER["REQUEST_URI"]` to prevent the unit test environment from failing

How to replicate:
1. Deploy local Moodle 4.5 instance with local_geniai installed
2. Initialize PHP unit test environment
3. Run `vendor/bin/phpunit lib/tests/core_renderer_test.php`
4. See the original error message
5. Apply the fix from `catalyst-master` branch
6. Re-run test and see the following output:
```
Moodle 4.5.2+ (Build: 20250314), dac9c54eb909d102a38809858956255894d95436
Php: 8.1.28, mysqli: 8.0.37, OS: Linux 6.8.0-52-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.........                                                           9 / 9 (100%)

Time: 00:10.734, Memory: 88.50 MB

OK (9 tests, 18 assertions)
```